### PR TITLE
Added GameworldState system

### DIFF
--- a/project_code/src/bat/mod.rs
+++ b/project_code/src/bat/mod.rs
@@ -4,16 +4,21 @@ mod components;
 mod systems;
 
 use systems::*;
+use crate::GameworldState;
 
 pub struct BatPlugin;
 
 impl Plugin for BatPlugin {
     /// Builds the bat plugin
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_bat)
-            .add_systems(Update, animate_bat)
-            .add_systems(Update, rotate_bat)
-            .add_systems(Update, bat_attack)
-            .add_systems(Update, bat_damaged);
+        app.add_systems(OnEnter(GameworldState::Island), spawn_bat)
+            .add_systems(Update, (
+                animate_bat,
+                rotate_bat,
+                bat_attack,
+                bat_damaged,
+            )
+            .run_if(in_state(GameworldState::Island)))
+            .add_systems(OnExit(GameworldState::Island), despawn_all_bats);
     }
 }

--- a/project_code/src/bat/systems.rs
+++ b/project_code/src/bat/systems.rs
@@ -107,17 +107,13 @@ pub fn spawn_bat(
     ));
 }
 
-/*
-    Detects when player is within Bat attack range and attacks.
-
-    Things not added:
-    - Attack cooldown timer
-    - Projectile shooting
-
-    Things currently added:
-    - Distance-to-player checking
-
-*/
+/*   BAT_ATTACK FUCNTION   */
+/// Detects when player is within Bat attack range and attacks.
+/// Things not added:
+/// * Attack cooldown timer
+/// * Projectile shooting
+/// Things currently added:
+/// * Distance-to-player checking
 pub fn bat_attack(
     time: Res<Time>,
     mut bat_query: Query<(&Transform, &mut AttackCooldown), With<Bat>>,
@@ -144,10 +140,9 @@ pub fn bat_attack(
     }
 }
 
-/*
-    Current functionality: Detects when a player is within player attack range (this will later be replaced with
-    player weapon/attack collision) and then takes 1 damage (dies)
-*/
+/*   BAT_DAMAGED FUNCTION   */
+/// Current functionality: Detects when a player is within player attack range (this will later be replaced with
+// player weapon/attack collision) and then takes 1 damage (dies)
 pub fn bat_damaged(
     mut commands: Commands,
     mut bat_query: Query<(&Transform, &mut Bat, Entity), With<Bat>>,
@@ -173,5 +168,17 @@ pub fn bat_damaged(
         } else {
             println!("Bat was attacked by player");
         }
+    }
+}
+
+/*   DESPAWN_ALL_BAT FUNCTION   */
+/// Despawns a bat entity
+/// DEBUG: Despwans all bat entities
+pub fn despawn_all_bats(
+    mut commands: Commands,
+    query: Query<Entity, With <Bat>>,
+) {
+    for entity in query.iter() {
+        commands.entity(entity).despawn();
     }
 }

--- a/project_code/src/boat/mod.rs
+++ b/project_code/src/boat/mod.rs
@@ -1,8 +1,11 @@
 use bevy::prelude::*;
 
-mod components;
-mod systems;
+pub mod components;
+pub mod systems;
+
 use systems::*;
+use crate::GameworldState;
+use crate::player::systems::despawn_player;
 
 pub struct BoatPlugin;
 
@@ -10,7 +13,8 @@ impl Plugin for BoatPlugin {
     /// Builds the boat plugin
     fn build(&self, app: &mut App) {
             app
-                .add_systems(Update,move_boat)
-                .add_systems(Update,spawn_boat);
+                .add_systems(OnEnter(GameworldState::Ocean),spawn_boat.after(despawn_player))
+                .add_systems(Update,move_boat.run_if(in_state(GameworldState::Ocean)))
+                .add_systems(OnExit(GameworldState::Ocean), despawn_boat);
     }
 }

--- a/project_code/src/boat/systems.rs
+++ b/project_code/src/boat/systems.rs
@@ -73,3 +73,15 @@ pub fn spawn_boat(
         },
     ));
 }
+
+/*   DESPAWN_BOAT FUNCTION   */
+/// Despawns the boat
+/// DEBUG: Will despawn any and all boats
+pub fn despawn_boat(
+    mut commands: Commands,
+    query: Query<Entity, With<Boat>>,
+) {
+    for entity in query.iter() {
+        commands.entity(entity).despawn();
+    }
+}

--- a/project_code/src/components.rs
+++ b/project_code/src/components.rs
@@ -2,3 +2,14 @@ use bevy::prelude::*;
 
 #[derive(Component)]
 pub struct Background;
+
+/*   GAMEWORLD STATES   */
+/// Enum to represent the different states the gameworld can be in. Depending on the state of the gameeworld,
+/// different enemies may spawn, the player controls a different entity (boat or player), etc. These states include
+/// * Island
+/// * Ocean
+#[derive(States, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum GameworldState {
+    Island,  //the state the gameworld will be in when exploring islands
+    Ocean,   //the state the gameworld will be in when exploring the ocean
+}

--- a/project_code/src/main.rs
+++ b/project_code/src/main.rs
@@ -7,19 +7,23 @@ mod components;
 mod hitbox_system;
 mod controls;
 
+use components::GameworldState;
 use data::gameworld_data::*;
 use bevy::{prelude::*, window::PresentMode};
 use player::PlayerPlugin;
+use boat::BoatPlugin;
 use hitbox_system::HitboxPlugin;
 use bat::BatPlugin;
 use systems::*;
+use player::systems::move_player;
+use boat::systems::move_boat;
 
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
-                title: "Sea of Fortune Build 0.2".into(),
+                title: "Sea of Fortune | Build 0.2".into(),
                 resolution: (WIN_W, WIN_H).into(),
                 present_mode: PresentMode::Fifo,
                 ..default()
@@ -28,8 +32,14 @@ fn main() {
         }))
         .add_systems(Startup, setup_gameworld)
         .add_plugins(PlayerPlugin)
+        .add_plugins(BoatPlugin)
         .add_plugins(BatPlugin)
         .add_plugins(HitboxPlugin)
-        .add_systems(Update, move_camera.after(player::systems::move_player))
+        .add_systems(Update, move_player_camera.after(move_player)
+                .run_if(in_state(GameworldState::Island)))
+        .add_systems(Update, move_boat_camera.after((move_boat))
+                .run_if(in_state(GameworldState::Ocean)))
+        .add_systems(Update, change_gameworld_state)
+        .insert_state(GameworldState::Island)
         .run();
 }

--- a/project_code/src/player/mod.rs
+++ b/project_code/src/player/mod.rs
@@ -4,16 +4,21 @@ pub mod components;
 pub mod systems;
 
 use systems::*;
+use crate::GameworldState;
 
 pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
     /// Builds the player plugin
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_player)
-            .add_systems(Update, move_player)
-            .add_systems(Update, player_animation.after(move_player))
-            .add_systems(Update, player_attack)
-            .add_systems(Update, check_player_health);
+        app.add_systems(OnEnter(GameworldState::Island),spawn_player)
+            .add_systems(Update, (    
+                move_player,
+                player_animation.after(move_player),
+                player_attack,
+                check_player_health,
+                )
+                .run_if(in_state(GameworldState::Island)))
+            .add_systems(OnExit(GameworldState::Island), despawn_player);
     }
 }

--- a/project_code/src/player/systems.rs
+++ b/project_code/src/player/systems.rs
@@ -231,7 +231,7 @@ pub fn player_attack(
     
 }
 
-
+/*   CHECK_PLAYER_HEALTH FUNCTION   */
 /// Function checks the current state of the player's health
 /// if current health == 0 --> panic and close program
 pub fn check_player_health(
@@ -249,5 +249,17 @@ pub fn check_player_health(
         if timer.just_finished() {
             //player.health -=1;
         }
+    }
+}
+
+/*   DESPAWN_PLAYER FUNCTION   */
+/// Despawns the player entity
+/// DEBUG: Will despawn any and all players
+pub fn despawn_player(
+    mut commands: Commands,
+    query: Query<Entity, With<Player>>,
+) {
+    for entity in query.iter() {
+        commands.entity(entity).despawn();
     }
 }

--- a/project_code/src/systems.rs
+++ b/project_code/src/systems.rs
@@ -1,13 +1,13 @@
 use crate::player::components::*;
-use crate::player::systems::*;
+use crate::boat::components::*;
 use bevy::{prelude::*, window::PresentMode};
 use crate::data::gameworld_data::*;
 use crate::components::*;
 
-
-/// Updates the cameras position to center the current player entity
+/*   MOVE_CAMERA_ FUNCTIONS  */
+/// Updates the cameras position to center the current player
 /// and tracks the player wherever they go
-pub fn move_camera(
+pub fn move_player_camera(
     player: Query<&Transform, With<Player>>,
     mut camera: Query<&mut Transform, (Without<Player>, With<Camera>)>,
 ) {
@@ -20,6 +20,22 @@ pub fn move_camera(
     ct.translation.y = pt.translation.y.clamp(-y_bound, y_bound);
 }
 
+/// Updates the cameras position to the center of the current
+/// players boats and track it wherever they go
+pub fn move_boat_camera(
+    boat: Query<&Transform, With<Boat>>,
+    mut camera: Query<&mut Transform, (Without<Boat>, With<Camera>)>,
+) {
+    let bt = boat.single();
+    let mut ct = camera.single_mut();
+
+    let x_bound = LEVEL_W / 2. - WIN_W / 2.;
+    let y_bound = LEVEL_H / 2. - WIN_H / 2.;
+    ct.translation.x = bt.translation.x.clamp(-x_bound, x_bound);
+    ct.translation.y = bt.translation.y.clamp(-y_bound, y_bound);
+}
+
+/*   SETUP_GAMEWORLD FUCNTION   */
 /// Sets up the gameworld
 pub fn setup_gameworld(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
@@ -35,4 +51,21 @@ pub fn setup_gameworld(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..default()
         })
         .insert(Background);
+}
+
+/*   CHANGE_GAMEWORLD_STATE FUNCTION   */
+/// Changes the state of the gameworld
+/// DEBUG: On keypress, the gameworld will switch
+/// * I - Island
+/// * O - Ocean
+pub fn change_gameworld_state(
+    mut state: Res<State<GameworldState>>,
+    mut next_state: ResMut<NextState<GameworldState>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyI) {
+        next_state.set(GameworldState::Island);
+    } else if keyboard_input.just_pressed(KeyCode::KeyO) {
+        next_state.set(GameworldState::Ocean);
+    }
 }


### PR DESCRIPTION
Added a state system that is able to switch between Island state and Ocean state. Ocean state the state where the player controls the boat and Overworld ocean enemies spawn. Island mode is the exploration mode the player is in while exploring islands. For debug purposes, all that changes is the players controllable entity and the entities that can spawn. The background stays statically on the sandy debug. 

BUG: The boat is scaled down to an extremely small degree for some odd reason. If someone can take a look let me know